### PR TITLE
Fixed incorrect capitalisation causing 404 error in wifi commands link

### DIFF
--- a/HERO6/README.md
+++ b/HERO6/README.md
@@ -9,5 +9,5 @@ The HERO6 Black camera shares the same HTTP calls HERO4 Black, but the HERO5 has
 * [Live Streaming](/HERO4/Livestreaming.md)
 * [Media Browsing](/HERO5/Mediabrowsing.md)
 * [Camera Status (HERO6-only status messages not included)](/HERO4/CameraStatus.md)
-* [Wifi Commands (HERO6-only commands not included)](/HERO5/HERO5-commands.md)
+* [Wifi Commands (HERO6-only commands not included)](/HERO5/HERO5-Commands.md)
 * [HERO6 Black specific commands, status and notes](/HERO6/HERO6-Commands.md)


### PR DESCRIPTION
This is just a fix to the documentation. Nothing else is new. 