### PR TITLE
?t=PASSWORD

### DIFF
--- a/HERO3/CameraStatus.md
+++ b/HERO3/CameraStatus.md
@@ -2,7 +2,7 @@
 
 #### GoPro HERO3/3+
 
-GET the contents of this: http://10.5.5.9/camera/sx
+GET the contents of this: http://10.5.5.9/camera/sx?t=PASSWORD
 
 See the available framerates for each resolution [here](/HERO3/Framerates-Resolutions.md)
 


### PR DESCRIPTION
http://10.5.5.9/camera/sx - get "403 Forbidden".

After I send - http://10.5.5.9/camera/sx?t=PASSWORD - browser download "sx" file.
"sx" file contains:
0003 0000 0002 0000 0006 00ff 0000 0200
0000 1003 0124 dc00 0001 f800 0600 0400
0000 0000 0000 0000 0000 0000 0000 0000
0000 0304 0000 0000 

I mean, correct is: http://10.5.5.9/camera/sx?t=PASSWORD

I have GoPro Hero3 Silver.

* GoPro Camera(s):
* Tested on:
* Firmware version:
