### PR TITLE
Hero 3 Black also uses HEX for Date Time

### DIFF
--- a/HERO3/WifiCommands.md
+++ b/HERO3/WifiCommands.md
@@ -45,7 +45,7 @@ HTTP Response Codes:
 	* Minute
 	* Second
 
-	**Example if you have Hero3+Black with FW v03.03 (They are using HEX now):**
+	**Example if you have Hero3 Black or Hero3+ Black with FW v03.03 (They are using HEX now):**
 
 	Y  -M - D H : m : s
 


### PR DESCRIPTION
3 Black also uses HEX for Date Time

* GoPro Camera(s): Hero 3 Black
* Tested on: Hero 3 Black
* Firmware version: HD3.03.03.00
