### PR TITLE
Add HERO 9 LiveStreaming

### DIFF
--- a/HERO9/GoPro-Connect.md
+++ b/HERO9/GoPro-Connect.md
@@ -18,14 +18,6 @@ Start recording/taking a photo works (see: https://twitter.com/konrad_it/status/
 - Linear FOV: http://172.XX.XXX.51/gp/gpWebcam/SETTINGS?fov=4
 - Narrow FOV: http://172.XX.XXX.51/gp/gpWebcam/SETTINGS?fov=6
 
-### For Wifi
-
-**NOTE**: The UDP streaming is directed to the IP who sent the API by HTTP GET, instead of broadcasting. And you need to constantly GET (every 25s or so) to keep the streaming alive.
-
-- Webcam mode START: http://10.5.5.9/gp/gpControl/execute?p1=gpStream&c1=start
-- Webcam mode STOP: http://10.5.5.9/gp/gpControl/execute?p1=gpStream&c1=stop
-- Webcam mode RESTART: http://10.5.5.9/gp/gpControl/execute?p1=gpStream&c1=restart
-
 ## Media browsing:
 
 JSON media list exposed under http://172.XX.XXX.51/gp/gpMediaList 
@@ -35,7 +27,6 @@ Thumbail endpoint works as well.
 ## Live preview
 
 After Webcam mode START, a live stream will be started and streamed out on UDP port 8554.
-
 
 VLC command: ```vlc -vvv --network-caching=300 --sout-x264-preset=ultrafast --sout-x264-tune=zerolatency --sout-x264-vbv-bufsize 0 --sout-transcode-threads 4 --no-audio udp://@:8554```
 

--- a/HERO9/GoPro-Connect.md
+++ b/HERO9/GoPro-Connect.md
@@ -18,6 +18,14 @@ Start recording/taking a photo works (see: https://twitter.com/konrad_it/status/
 - Linear FOV: http://172.XX.XXX.51/gp/gpWebcam/SETTINGS?fov=4
 - Narrow FOV: http://172.XX.XXX.51/gp/gpWebcam/SETTINGS?fov=6
 
+### For Wifi
+
+**NOTE**: The UDP streaming is directed to the IP who sent the API by HTTP GET, instead of broadcasting. And you need to constantly GET (every 25s or so) to keep the streaming alive.
+
+- Webcam mode START: http://10.5.5.9/gp/gpControl/execute?p1=gpStream&c1=start
+- Webcam mode STOP: http://10.5.5.9/gp/gpControl/execute?p1=gpStream&c1=stop
+- Webcam mode RESTART: http://10.5.5.9/gp/gpControl/execute?p1=gpStream&c1=restart
+
 ## Media browsing:
 
 JSON media list exposed under http://172.XX.XXX.51/gp/gpMediaList 

--- a/HERO9/Livestreaming.md
+++ b/HERO9/Livestreaming.md
@@ -1,0 +1,22 @@
+## Commands:
+
+**NOTE**: SETTINGS will follow those in [Wifi Commands](/HERO9/HERO9-Commands.md)
+
+- LiveStreaming mode START: http://10.5.5.9/gp/gpControl/execute?p1=gpStream&c1=start
+- LiveStreaming mode STOP: http://10.5.5.9/gp/gpControl/execute?p1=gpStream&c1=stop
+- LiveStreaming mode RESTART: http://10.5.5.9/gp/gpControl/execute?p1=gpStream&c1=restart
+
+## Media browsing:
+
+JSON media list exposed under http://10.5.5.9/gp/gpMediaList 
+
+Thumbail endpoint works as well.
+
+## Live preview
+
+After LiveStreaming mode START, a live stream will be started and streamed out on UDP port 8554.
+
+**NOTE**: The UDP streaming is directed to the IP who sent the API by HTTP GET, instead of broadcasting. And you need to constantly GET (every 25s or so) to keep the streaming alive.
+
+
+ffmpeg command: ```ffplay udp://10.5.5.9:8554```


### PR DESCRIPTION
* GoPro Camera(s): Hero 9
* Tested on: Hero 9
* Firmware version: 01.52

I guess this feature does not belong to the GoPro-Connect.md, it is simply the feature "Preview" in the "GoPro Quik" app.

So the file GoPro-Connect.md is left unchanged.