### PR TITLE
Added documentation for bitrate option

### DIFF
--- a/HERO9/GoPro-Connect.md
+++ b/HERO9/GoPro-Connect.md
@@ -17,6 +17,9 @@ Start recording/taking a photo works (see: https://twitter.com/konrad_it/status/
 - Wide FOV: http://172.XX.XXX.51/gp/gpWebcam/SETTINGS?fov=0
 - Linear FOV: http://172.XX.XXX.51/gp/gpWebcam/SETTINGS?fov=4
 - Narrow FOV: http://172.XX.XXX.51/gp/gpWebcam/SETTINGS?fov=6
+- 1 Mbps Bitrate: http://172.XX.XXX.51/gp/gpWebcam/SETTINGS?bitrate=1000000
+- 2 Mbps Bitrate: http://172.XX.XXX.51/gp/gpWebcam/SETTINGS?bitrate=2000000
+- 5 Mbps Bitrate: http://172.XX.XXX.51/gp/gpWebcam/SETTINGS?bitrate=5000000
 
 ## Media browsing:
 


### PR DESCRIPTION
This adds some examples for configuring the bitrate of the webcam output feed. I am unsure if this also exists on the HERO9, but it exists on the HERO10 firmware.

* GoPro Camera(s): HERO10
* Tested on: HERO10
* Firmware version: H21.01.01.46.00
